### PR TITLE
Release Automation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,18 +1,26 @@
 name: Pull Request Checks
+
 on:
   pull_request:
     types:
     - opened
     - reopened
     - synchronize
+
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.0.2
-    - uses: actions/setup-go@v3.3.0
+
+    - name: Checkout Source
+      uses: actions/checkout@v3.0.2
+
+    - name: Setup Go
+      uses: actions/setup-go@v3.3.0
       with:
-        go-version-file: 'go.mod'
+        go-version-file: go.mod
         check-latest: true
         cache: true
-    - run: make test
+
+    - name: Run Tests
+      run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout Source
+      uses: actions/checkout@v3.0.2
+
+    - name: Setup Go
+      uses: actions/setup-go@v3.3.0
+      with:
+        go-version-file: go.mod
+        check-latest: true
+        cache: true
+
+    - name: Publish Image
+      run: make image
+      env:
+        KO_DOCKER_REPO: ghcr.io/nebhale
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout Source
+      uses: actions/checkout@v3.0.2
+      with:
+        fetch-depth: 0
+
+    - name: Fetch All Tags
+      run: git fetch --force --tags
+
+    - name: Setup Go
+      uses: actions/setup-go@v3.3.0
+      with:
+        go-version-file: go.mod
+        check-latest: true
+        cache: true
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v3.1.0
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,5 @@
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
-
-# Test binary, built with `go test -c`
-*.test
 __debug_bin
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
 !.vscode/launch.json
 !.vscode/settings.json
 !.vscode/snippets.code-snippets
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,33 @@
+gomod:
+  proxy: true
+before:
+  hooks:
+  - go mod tidy
+builds:
+- main: ./cmd/teslamate-discovery
+  goos:
+  - linux
+  - windows
+  - darwin
+  goarch:
+  - amd64
+  - arm64
+  flags:
+  - -trimpath
+universal_binaries:
+- replace: true
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    amd64: x86_64
+  format_overrides:
+  - goos: windows
+    format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  use: github-native

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "crosshairs",
     "Frunk",
     "goimports",
+    "goreleaser",
     "homeassistant",
     "iancoleman",
     "MQTT",

--- a/Makefile
+++ b/Makefile
@@ -67,4 +67,5 @@ run: ## Run the application.
 
 .PHONY: image
 image: ## Build the image.
-	VERSION=$(VERSION) $(KO) build --platform $(KO_PLATFORMS) --base-import-paths ./cmd/teslamate-discovery
+	VERSION=$(VERSION) $(KO) build --platform $(KO_PLATFORMS) --base-import-paths --tags $(VERSION) --tags latest \
+		./cmd/teslamate-discovery


### PR DESCRIPTION
This change adds release automation support based on the goreleaser project.  This automation creates a GitHub release with a changelog, attaches binaries to the release and publishes a multi-arch Docker Image.