### PR TITLE
Time to Charge Unit of measurement

### DIFF
--- a/mqtt/publish_discovery.go
+++ b/mqtt/publish_discovery.go
@@ -95,7 +95,7 @@ func (m *MQTT) PublishDiscovery(ctx context.Context, id string, device ha.Device
 			Name:              Name(device, "Time to Charged"),
 			StateTopic:        StateTopic(device, "/time_to_full_charge"),
 			UniqueId:          UniqueId(device, "/time_to_charged"),
-			UnitOfMeasurement: "hours",
+			UnitOfMeasurement: "h",
 		},
 
 		// Climate


### PR DESCRIPTION
Previously the time_to_charge unit of measurement was 'hours' which is not a valid unit for duration. This change updates it to 'h' which is the correct value for hours.
