### PR TITLE
setup-go Updates

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,6 @@ jobs:
       with:
         go-version-file: go.mod
         check-latest: true
-        cache: true
 
     - name: Run Tests
       run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
       with:
         go-version-file: go.mod
         check-latest: true
-        cache: true
 
     - name: Publish Image
       run: make image


### PR DESCRIPTION
This change removes a key from the setup-go configuration as the latest versions no longer require it.
