### PR TITLE
Name Not Populated

### DIFF
--- a/mqtt/list_vehicles.go
+++ b/mqtt/list_vehicles.go
@@ -59,6 +59,9 @@ func (m *MQTT) ListVehicles(ctx context.Context, tmCfg tm.Config) (map[string]ha
 
 		case <-time.After(250 * time.Millisecond):
 			for id, dev := range vehicles {
+				if dev.Name == "" {
+					dev.Name = "Tesla"
+				}
 				dev.Identifiers = []string{fmt.Sprintf("%s/cars/%s", tmCfg.Prefix, id)}
 				dev.Manufacturer = "Tesla"
 				dev.SuggestedArea = "Garage"

--- a/mqtt/list_vehicles_test.go
+++ b/mqtt/list_vehicles_test.go
@@ -68,6 +68,19 @@ func TestMQTT_ListVehicles(t *testing.T) {
 							topic:   "test-prefix/cars/2/version",
 							payload: []byte("test-version-2"),
 						})
+
+						cb(nil, &stubMessage{
+							topic:   "test-prefix/cars/3/trim_badging",
+							payload: []byte("test-trim-badging-3"),
+						})
+						cb(nil, &stubMessage{
+							topic:   "test-prefix/cars/3/model",
+							payload: []byte("test-model-3"),
+						})
+						cb(nil, &stubMessage{
+							topic:   "test-prefix/cars/3/version",
+							payload: []byte("test-version-3"),
+						})
 					},
 					subscribeTokens: []paho.Token{&stubToken{}},
 				},
@@ -91,6 +104,14 @@ func TestMQTT_ListVehicles(t *testing.T) {
 					Model:           "Model test-model-2 test-trim-badging-2",
 					Name:            "test-display-name-2",
 					SoftwareVersion: "test-version-2",
+					SuggestedArea:   "Garage",
+				},
+				"3": {
+					Identifiers:     []string{"test-prefix/cars/3"},
+					Manufacturer:    "Tesla",
+					Model:           "Model test-model-3 test-trim-badging-3",
+					Name:            "Tesla",
+					SoftwareVersion: "test-version-3",
 					SuggestedArea:   "Garage",
 				},
 			},


### PR DESCRIPTION
Previously, if a user had not set their vehicle's Display Name, the generated entity id's would be created with nothing ahead of the first underscore (e.g. 'sensor._longitude') and names would have nothing ahead of the first space (e.g. ' Longitude').  This change adds a default name of 'Tesla' to any vehicle that does not have a Display Name set.

[resolves #44]
