### PR TITLE
Range Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Flags:
   -p, --mqtt-port int                mqtt broker port (default 8883)
   -s, --mqtt-scheme string           mqtt broker scheme (default "ssl")
   -u, --mqtt-username string         mqtt broker username
+      --range-type string            range type ["estimated", "ideal", "rated"] (default "rated")
       --tm-prefix string             teslamate message prefix (default "teslamate")
       --units-distance string        distance units ["imperial", "metric"] (default "imperial")
       --units-pressure string        pressure units ["imperial", "metric"] (default "imperial")

--- a/cmd/teslamate-discovery/main.go
+++ b/cmd/teslamate-discovery/main.go
@@ -81,6 +81,13 @@ func CreateCommand() (*cobra.Command, *viper.Viper) {
 	_ = viper.BindEnv("tm.prefix", "TM_PREFIX")
 	viper.SetDefault("tm.prefix", tm.DefaultPrefix)
 
+	r := units.DefaultRangeType
+	flags.Var(&r, "range-type", "range type [\"estimated\", \"ideal\", \"rated\"]")
+	_ = cmd.RegisterFlagCompletionFunc("range-type", units.RangeTypeCompletion)
+	_ = viper.BindPFlag("units.range_type", flags.Lookup("range-type"))
+	_ = viper.BindEnv("units.range_type", "UNITS_RANGE_TYPE")
+	viper.SetDefault("units.range_type", units.DefaultRangeType)
+
 	d := units.DefaultDistance
 	flags.Var(&d, "units-distance", "distance units [\"imperial\", \"metric\"]")
 	_ = cmd.RegisterFlagCompletionFunc("units-distance", units.SystemOfMeasurementCompletion)

--- a/mqtt/publish_discovery.go
+++ b/mqtt/publish_discovery.go
@@ -294,7 +294,7 @@ func (m *MQTT) PublishDiscovery(ctx context.Context, id string, device ha.Device
 			Icon:              "mdi:map-marker-distance",
 			Name:              Name(device, "Range"),
 			StateClass:        ha.Measurement,
-			StateTopic:        StateTopic(device, "/rated_battery_range_km"),
+			StateTopic:        StateTopic(device, fmt.Sprintf(`/%s_battery_range_km`, unitsCfg.RangeType.Prefix())),
 			UniqueId:          UniqueId(device, "/range"),
 			UnitOfMeasurement: unitsCfg.Distance.DistanceLongUnits(),
 			ValueTemplate:     unitsCfg.Distance.DistanceLongValueTemplate(),

--- a/units/config.go
+++ b/units/config.go
@@ -4,16 +4,19 @@
 package units
 
 const (
-	DefaultDistance = Imperial
-	DefaultPressure = Imperial
+	DefaultDistance  = Imperial
+	DefaultPressure  = Imperial
+	DefaultRangeType = Rated
 )
 
 var DefaultConfig = Config{
-	Distance: DefaultDistance,
-	Pressure: DefaultPressure,
+	Distance:  DefaultDistance,
+	Pressure:  DefaultPressure,
+	RangeType: DefaultRangeType,
 }
 
 type Config struct {
-	Distance SystemOfMeasurement `mapstructure:"distance"`
-	Pressure SystemOfMeasurement `mapstructure:"pressure"`
+	Distance  SystemOfMeasurement `mapstructure:"distance"`
+	Pressure  SystemOfMeasurement `mapstructure:"pressure"`
+	RangeType RangeType           `mapstructure:"range_type"`
 }

--- a/units/range_type.go
+++ b/units/range_type.go
@@ -1,0 +1,53 @@
+package units
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type RangeType string
+
+const (
+	Estimated RangeType = "estimated"
+	Ideal     RangeType = "ideal"
+	Rated     RangeType = "rated"
+)
+
+func (r RangeType) Prefix() string {
+	if r == Estimated {
+		return "est"
+	}
+
+	if r == Ideal {
+		return "ideal"
+	}
+
+	return "rated"
+}
+
+func (r *RangeType) Set(v string) error {
+	switch v {
+	case "estimated":
+		*r = Estimated
+	case "ideal":
+		*r = Ideal
+	case "rated":
+		*r = Rated
+	default:
+		return fmt.Errorf("must be one of estimated, ideal, rated")
+	}
+	return nil
+}
+
+func (r RangeType) String() string {
+	return string(r)
+}
+
+func (r RangeType) Type() string {
+	return "string"
+}
+
+func RangeTypeCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{string(Estimated), string(Ideal), string(Rated)}, cobra.ShellCompDirectiveDefault
+}

--- a/units/range_type_test.go
+++ b/units/range_type_test.go
@@ -1,0 +1,183 @@
+package units
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRangeType_Prefix(t *testing.T) {
+	tests := []struct {
+		name string
+		r    RangeType
+		want string
+	}{
+		{
+			name: "estimated",
+			r:    Estimated,
+			want: "est",
+		},
+		{
+			name: "ideal",
+			r:    Ideal,
+			want: "ideal",
+		},
+		{
+			name: "rated",
+			r:    Rated,
+			want: "rated",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.r.Prefix(); got != tt.want {
+				t.Errorf("RangeType.Prefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRangeType_Set(t *testing.T) {
+	type args struct {
+		v string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    RangeType
+		wantErr bool
+	}{
+		{
+			name: "estimated",
+			args: args{v: "estimated"},
+			want: Estimated,
+		},
+		{
+			name: "ideal",
+			args: args{v: "ideal"},
+			want: Ideal,
+		},
+		{
+			name: "rated",
+			args: args{v: "rated"},
+			want: Rated,
+		},
+		{
+			name:    "unknown",
+			args:    args{v: "unknown"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r RangeType
+			err := r.Set(tt.args.v)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RangeType.Set() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if r != tt.want {
+				t.Errorf("RangeType.Set() = %v, want %v", r, tt.want)
+			}
+		})
+	}
+}
+
+func TestRangeType_String(t *testing.T) {
+	tests := []struct {
+		name string
+		r    RangeType
+		want string
+	}{
+		{
+			name: "estimated",
+			r:    Estimated,
+			want: "estimated",
+		},
+		{
+			name: "ideal",
+			r:    Ideal,
+			want: "ideal",
+		},
+		{
+			name: "rated",
+			r:    Rated,
+			want: "rated",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.r.String(); got != tt.want {
+				t.Errorf("RangeType.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRangeType_Type(t *testing.T) {
+	tests := []struct {
+		name string
+		r    RangeType
+		want string
+	}{
+		{
+			name: "estimated",
+			r:    Estimated,
+			want: "string",
+		},
+		{
+			name: "ideal",
+			r:    Ideal,
+			want: "string",
+		},
+		{
+			name: "rated",
+			r:    Rated,
+			want: "string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.r.Type(); got != tt.want {
+				t.Errorf("RangeType.Type() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRangeTypeCompletion(t *testing.T) {
+	type args struct {
+		cmd        *cobra.Command
+		args       []string
+		toComplete string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  []string
+		want1 cobra.ShellCompDirective
+	}{
+		{
+			name:  "always",
+			args:  args{},
+			want:  []string{"estimated", "ideal", "rated"},
+			want1: cobra.ShellCompDirectiveDefault,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := RangeTypeCompletion(tt.args.cmd, tt.args.args, tt.args.toComplete)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RangeTypeCompletion() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("RangeTypeCompletion() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/units/system_of_measurement.go
+++ b/units/system_of_measurement.go
@@ -70,10 +70,10 @@ func (s *SystemOfMeasurement) Set(v string) error {
 	switch v {
 	case "imperial", "metric":
 		*s = SystemOfMeasurement(v)
-		return nil
 	default:
 		return fmt.Errorf("must be one of imperial, metric")
 	}
+	return nil
 }
 
 func (s SystemOfMeasurement) String() string {


### PR DESCRIPTION
Previously the range topic was hard coded to always map to the rated range.  A user reported that there are some models for which rated isn't a good fit and requested that other range types be available.  This
change adds a `--range-type` flag to the CLI that lets a user select between estimated, ideal, and rated (default) for the range topic.

[resolves #21]