### PR TITLE
Dependabot Config Update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
   - tools
 
 - package-ecosystem: gomod
-  directory: "/hack/ko"
+  directory: "/hack/goreleaser"
   schedule:
     interval: daily
   labels:


### PR DESCRIPTION
This change updates the Dependabot config to watch for changes to goreleaser instead of ko.
